### PR TITLE
Add a `timeStep` for print progress notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoPrint-OctoRant 1.3.2
+# OctoPrint-OctoRant 1.3.0
 
 OctoRant is a plugin allowing Octoprint to send notifications to a Discord channel via a webhook URL. When wanted it can directly send a snapshot to Discord (without needing third-party services)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoPrint-OctoRant 1.3.0
+# OctoPrint-OctoRant 1.3.1
 
 OctoRant is a plugin allowing Octoprint to send notifications to a Discord channel via a webhook URL. When wanted it can directly send a snapshot to Discord (without needing third-party services)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoPrint-OctoRant 1.3.1
+# OctoPrint-OctoRant 1.3.2
 
 OctoRant is a plugin allowing Octoprint to send notifications to a Discord channel via a webhook URL. When wanted it can directly send a snapshot to Discord (without needing third-party services)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoPrint-OctoRant 1.2.3
+# OctoPrint-OctoRant 1.3.0
 
 OctoRant is a plugin allowing Octoprint to send notifications to a Discord channel via a webhook URL. When wanted it can directly send a snapshot to Discord (without needing third-party services)
 
@@ -6,7 +6,7 @@ OctoRant is a plugin allowing Octoprint to send notifications to a Discord chann
 
 OctoRant is *one-way only*, from your printer to your Discord channel. This plugin **is not able** to receive commands for your printer from Discord. However a good fellow @cameroncros forked my plugin exactly to add this feature. Feel free to try [DiscordRemote](https://plugins.octoprint.org/plugins/DiscordRemote/)
 
-License : MIT 
+License : MIT
 
 ![Screeshot of the Discord messages](assets/img/discord.jpg)
 
@@ -56,8 +56,8 @@ Here you can customize every message handled by Octorant.
 
 - **Toggle the message** : by unchecking the checkbox in front of the message title, you can disable the message. It won't be sent to Discord.
 - **Message** : you can change the default content here. See the section [Message format](#message-format) for more information.
-- **Include snapshot** : if you have a snapshot URL defined in the Octoprint settings, you can choose to upload a snapshot with the message to Discord. 
-- **Notify every `XX`%** : specific to the `printing progress` message, this settings allows you to change the frequency of the notification : 
+- **Include snapshot** : if you have a snapshot URL defined in the Octoprint settings, you can choose to upload a snapshot with the message to Discord.
+- **Notify every `XX`%** : specific to the `printing progress` message, this settings allows you to change the frequency of the notification :
     - `10%` means you'll receive a message at 10%, 20%, 30%, 40% ... 80%, 90% of the printing process.
     - `5%` means you'll receive a message at 5%, 10%, 15%, 20% ... 80%, 85%, 90%, 95% of the printing process.
     - etc...
@@ -79,7 +79,7 @@ Messages are regular Discord messages, which means you can use :
 - `:emoji:` shortcuts to display emojis
 - `@mentions` to notify someone
 
-Some events also support variables, here is a basic list : 
+Some events also support variables, here is a basic list :
 
 **Printing process : started event** :
 - `{name}` : file's name that's being printed
@@ -91,7 +91,7 @@ Some events also support variables, here is a basic list :
 - `{path}` : file's path within its origin location
 - `{origin}` : the origin storage location
 
-**Printing process : done event** : 
+**Printing process : done event** :
 - `{name}` : file's name that's being printed
 - `{path}` : file's path within its origin location
 - `{origin}` : the origin storage location
@@ -124,7 +124,7 @@ Some events also support variables, here is a basic list :
 - `{remaining_formatted}` : same as `{remaining}`, but in a human-readable format (`HH:MM:SS`)
 
 **Printer state : error**
-- `{error}` : The error received 
+- `{error}` : The error received
 
 For more reference, you can go to the [Octoprint documentation on Events](http://docs.octoprint.org/en/master/events/index.html#sec-events-available-events)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoPrint-OctoRant 1.2.2
+# OctoPrint-OctoRant 1.2.3
 
 OctoRant is a plugin allowing Octoprint to send notifications to a Discord channel via a webhook URL. When wanted it can directly send a snapshot to Discord (without needing third-party services)
 

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -249,6 +249,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 				return False # Don't notify
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
+			self._logger.debug("Estimated print time minutes is " + estimatedPrintTimeMinutes)
 			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > tmpConfig["timeStep"]):
 				# Notify if it's been a while since our last notification (timeStep)
 				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["timeStep"]):

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -240,7 +240,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 			int(tmpConfig["step"]) == 0 \
 			or int(data["progress"]) == 0 \
 			or int(data["progress"]) % int(tmpConfig["step"]) != 0 \
-			or (datetime.now()-self.lastNotificationTimestamp).total_seconds()/60 < int(tmpConfig["timeStep"]) \
+			or (datetime.now(timezone.utc)-self.lastNotificationTimestamp).total_seconds()/60 < int(tmpConfig["timeStep"]) \
 			or (int(data["progress"]) == 100) \
 		) :
 			return False
@@ -358,7 +358,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 
 		out = discordCall.start()
 
-		self.lastNotificationTimestamp = datetime.now()
+		self.lastNotificationTimestamp = datetime.now(timezone.utc)
 
 		# exec "after" script if any
 		self.exec_script(eventID, "after")

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -250,7 +250,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
 			self._logger.info("Estimated print time in minutes is " + str(estimatedPrintTimeMinutes))
-			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > float(tmpConfig["timeStep"])):
+			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/int(tmpConfig["step"])) > float(tmpConfig["timeStep"])):
 				self._logger.info("Checking if we need to notify based on minutes passed")
 				# Notify if it's been a while since our last notification (timeStep)
 				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["timeStep"]):

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -249,8 +249,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 				return False # Don't notify
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
-			self._logger.debug("Estimated print time minutes is " + estimatedPrintTimeMinutes)
-			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > tmpConfig["timeStep"]):
+			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > float(tmpConfig["timeStep"])):
 				# Notify if it's been a while since our last notification (timeStep)
 				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["timeStep"]):
 					# Reset the "timer" since we're about to send a progress notification

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -257,7 +257,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 					self._logger.info("Alerting because of minutes passed")
 					# Reset the "timer" since we're about to send a progress notification
 					self.lastProgressNotificationTimestamp = datetime.now(timezone.utc)
-				else
+				else:
 					self._logger.info("Time alert not ready yet")
 					return False # Don't notify
 			# Notify only if we're at a configured notification percentage (step)

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -194,6 +194,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 		if event == "PrintPaused":
 			return self.notify_event("printing_paused",payload)
 		if event == "PrintResumed":
+			self.lastNotificationTimestamp = datetime.now(timezone.utc)
 			return self.notify_event("printing_resumed",payload)
 		if event == "PrintCancelled":
 			return self.notify_event("printing_cancelled",payload)
@@ -250,6 +251,8 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 				and int(data["progress"]) % int(tmpConfig["step"]) != 0
 			):
 				return False
+			else:
+				self.lastNotificationTimestamp = datetime.now(timezone.utc)
 
 		tmpDataFromPrinter = self._printer.get_current_data()
 		if tmpDataFromPrinter["progress"] is not None and tmpDataFromPrinter["progress"]["printTimeLeft"] is not None:
@@ -363,8 +366,6 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 		)
 
 		out = discordCall.start()
-
-		self.lastNotificationTimestamp = datetime.now(timezone.utc)
 
 		# exec "after" script if any
 		self.exec_script(eventID, "after")

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -23,7 +23,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 	def __init__(self):
 		# Events definition here (better for intellisense in IDE)
 		# referenced in the settings too.
-		self.lastNotificationTimestamp = datetime.now()
+		self.lastNotificationTimestamp = datetime.now(),
 		self.events = {
 			"startup" : {
 				"name" : "Octoprint Startup",

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -249,7 +249,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 				return False # Don't notify
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
-			self._logger.info("Estimated print time in minutes is " + estimatedPrintTimeMinutes)
+			self._logger.info("Estimated print time in minutes is " + str(estimatedPrintTimeMinutes))
 			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > float(tmpConfig["timeStep"])):
 				self._logger.info("Checking if we need to notify based on minutes passed")
 				# Notify if it's been a while since our last notification (timeStep)

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -2,10 +2,10 @@
 from __future__ import absolute_import
 from .discord import Hook
 
-import json
 import octoprint.plugin
 import octoprint.settings
 import requests
+import datetime
 from datetime import timedelta
 from PIL import Image
 from io import BytesIO

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -5,8 +5,9 @@ from .discord import Hook
 import octoprint.plugin
 import octoprint.settings
 import requests
-import datetime
 from datetime import timedelta
+from datetime import datetime
+from datetime import timezone
 from PIL import Image
 from io import BytesIO
 import subprocess
@@ -23,7 +24,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 	def __init__(self):
 		# Events definition here (better for intellisense in IDE)
 		# referenced in the settings too.
-		self.lastNotificationTimestamp = datetime.now(),
+		self.lastNotificationTimestamp = datetime.now(timezone.utc),
 		self.events = {
 			"startup" : {
 				"name" : "Octoprint Startup",

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -169,7 +169,7 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 			if (\
 				# Check that both step config values aren't unset
 				int(tmpConfig["step"]) == 0 \
-				and int(tmpConfig["timeStep"]) == 0 \
+				and int(tmpConfig["time_step"]) == 0 \
 				# Don't notify about progress on 0% or 100% because other notifications fire then
 				or int(data["progress"]) == 0 \
 				or (int(data["progress"]) == 100) \
@@ -178,10 +178,10 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
 			self._logger.info("Estimated print time in minutes is " + str(estimatedPrintTimeMinutes))
-			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/int(tmpConfig["step"])) > float(tmpConfig["timeStep"])):
+			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/int(tmpConfig["step"])) > float(tmpConfig["time_step"])):
 				self._logger.info("Checking if we need to notify based on minutes passed")
-				# Notify if it's been a while since our last notification (timeStep)
-				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["timeStep"]):
+				# Notify if it's been a while since our last notification (time_step)
+				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["time_step"]):
 					self._logger.info("Alerting because of minutes passed")
 					# Reset the "timer" since we're about to send a progress notification
 					self.lastProgressNotificationTimestamp = datetime.now(timezone.utc)

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -249,16 +249,17 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 				return False # Don't notify
 
 			estimatedPrintTimeMinutes = self._printer.get_current_job()["estimatedPrintTime"]/60
+			self._logger.info("Estimated print time in minutes is " + estimatedPrintTimeMinutes)
 			if (estimatedPrintTimeMinutes is not None and estimatedPrintTimeMinutes/(100/tmpConfig["step"]) > float(tmpConfig["timeStep"])):
+				self._logger.info("Checking if we need to notify based on minutes passed")
 				# Notify if it's been a while since our last notification (timeStep)
 				if (datetime.now(timezone.utc)-self.lastProgressNotificationTimestamp).total_seconds()/60 >= int(tmpConfig["timeStep"]):
+					self._logger.info("Alerting because of minutes passed")
 					# Reset the "timer" since we're about to send a progress notification
 					self.lastProgressNotificationTimestamp = datetime.now(timezone.utc)
-			# Notify if we're at a configured notification percentage (step)
-			elif (int(data["progress"]) % int(tmpConfig["step"]) == 0):
-				# Reset the "timer" since we're about to send a progress notification
-				self.lastProgressNotificationTimestamp = datetime.now(timezone.utc)
-			else:
+			# Notify only if we're at a configured notification percentage (step)
+			elif (int(data["progress"]) % int(tmpConfig["step"]) != 0):
+				self._logger.info("Percentage progress alert not ready yet")
 				return False # Don't notify
 
 		tmpDataFromPrinter = self._printer.get_current_data()

--- a/octoprint_octorant/__init__.py
+++ b/octoprint_octorant/__init__.py
@@ -257,6 +257,9 @@ class OctorantPlugin(octoprint.plugin.EventHandlerPlugin,
 					self._logger.info("Alerting because of minutes passed")
 					# Reset the "timer" since we're about to send a progress notification
 					self.lastProgressNotificationTimestamp = datetime.now(timezone.utc)
+				else
+					self._logger.info("Time alert not ready yet")
+					return False # Don't notify
 			# Notify only if we're at a configured notification percentage (step)
 			elif (int(data["progress"]) % int(tmpConfig["step"]) != 0):
 				self._logger.info("Percentage progress alert not ready yet")

--- a/octoprint_octorant/events.py
+++ b/octoprint_octorant/events.py
@@ -84,7 +84,7 @@ EVENTS = {
         "enabled" : True,
         "with_snapshot": True,
         "message" : "📢 Printing is at {progress}%",
-        "timeStep" : 10,
+        "time_step" : 10,
         "time_step_unit":"minute(s)",
         "step" : 10,
         "step_unit":"%"

--- a/octoprint_octorant/events.py
+++ b/octoprint_octorant/events.py
@@ -85,6 +85,7 @@ EVENTS = {
         "with_snapshot": True,
         "message" : "📢 Printing is at {progress}%",
         "timeStep" : 10,
+        "time_step_unit":"minute(s)",
         "step" : 10,
         "step_unit":"%"
     },

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -50,7 +50,7 @@
         <div class="control-group" data-bind="if: $parent.settings.plugins.octorant.events[$data].timeStep">
             <label class="control-label">{{ _("or notify roughly every") }}</label>
             <div class="controls">
-		<input type="number" min="1" max="60" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].timeStep"/> minutes
+		<input type="number" min="1" max="60" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].timeStep"/> minute(s)
             </div>
         </div>
     </div>

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -56,11 +56,15 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="control-group" data-bind="if: $parent.settings.plugins.octorant.events[$data].timeStep">
-            <label class="control-label">{{ _("or notify roughly every") }}</label>
-            <div class="controls">
-		<input type="number" min="1" max="60" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].timeStep"/> minute(s)
+
+            <div class="control-group" data-bind="if: settings.plugins.octorant.events[id].timeStep, visible: settings.plugins.octorant.events[id].enabled">
+                <label class="control-label">{{ _("or notify roughly every") }}</label>
+                <div class="controls">
+                    <div class="input-append">
+                        <input type="number" min="1" max="60" step="1" data-bind="value: settings.plugins.octorant.events[id].timeStep"/>
+                        <span class="add-on" data-bind="text: settings.plugins.octorant.events[id].time_step_unit"></span>
+                    </div>
+                </div>
             </div>
         </div>
         <!-- /ko -->

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -48,7 +48,7 @@
             </div>
         </div>
         <div class="control-group" data-bind="if: $parent.settings.plugins.octorant.events[$data].timeStep">
-            <label class="control-label">{{ _("Notify roughly every") }}</label>
+            <label class="control-label">{{ _("or notify roughly every") }}</label>
             <div class="controls">
 		<input type="number" min="1" max="60" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].timeStep"/> minutes
             </div>

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -57,11 +57,11 @@
                 </div>
             </div>
 
-            <div class="control-group" data-bind="if: settings.plugins.octorant.events[id].timeStep, visible: settings.plugins.octorant.events[id].enabled">
+            <div class="control-group" data-bind="if: settings.plugins.octorant.events[id].time_step, visible: settings.plugins.octorant.events[id].enabled">
                 <label class="control-label">{{ _("or notify roughly every") }}</label>
                 <div class="controls">
                     <div class="input-append">
-                        <input type="number" min="1" max="60" step="1" data-bind="value: settings.plugins.octorant.events[id].timeStep"/>
+                        <input type="number" min="1" max="180" step="1" data-bind="value: settings.plugins.octorant.events[id].time_step"/>
                         <span class="add-on" data-bind="text: settings.plugins.octorant.events[id].time_step_unit"></span>
                     </div>
                 </div>

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -47,6 +47,12 @@
                 <input type="number" min="1" max="100" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].step"/>%
             </div>
         </div>
+        <div class="control-group" data-bind="if: $parent.settings.plugins.octorant.events[$data].timeStep">
+            <label class="control-label">{{ _("Notify roughly every") }}</label>
+            <div class="controls">
+		<input type="number" min="1" max="60" step="1" data-bind="value: $parent.settings.plugins.octorant.events[$data].timeStep"/> minutes
+            </div>
+        </div>
     </div>
 </form>
 <h3>Scripts settings</h3>
@@ -69,7 +75,7 @@
         </div>
         <div style="clear:both">
             <p>
-                {{ _("Here you can specify a file to be executed <strong>before</strong> and <strong>after</strong> each message is sent to Discord.") }} 
+                {{ _("Here you can specify a file to be executed <strong>before</strong> and <strong>after</strong> each message is sent to Discord.") }}
                 {{ _("<strong>The file should be executable by the user under which OctoPrint is running</strong>") }}
             </p>
         </div>

--- a/octoprint_octorant/templates/octorant_settings.jinja2
+++ b/octoprint_octorant/templates/octorant_settings.jinja2
@@ -64,7 +64,6 @@
             </div>
         </div>
         <!-- /ko -->
-
     </div>
 </form>
 <h3>Scripts settings</h3>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octorant"
 plugin_name = "OctoPrint-Octorant"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.2.3"
+plugin_version = "1.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octorant"
 plugin_name = "OctoPrint-Octorant"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.3.2"
+plugin_version = "1.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octorant"
 plugin_name = "OctoPrint-Octorant"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.3.1"
+plugin_version = "1.3.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octorant"
 plugin_name = "OctoPrint-Octorant"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.3.0"
+plugin_version = "1.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This PR adds a new setting internally called `timeStep`. `timeStep` configures a second condition for when to notify during print progress.

Without `timeStep`, if I have `step` set to notify me every 10% and I print a file that takes 10 hours, I'll receive a progress notification every 10% or one notification every hour. For longer prints, I like to be notified more frequently than that but if I set my `step` to something like 2% instead, I end up getting notified too frequently when I print a smaller item. With `timeStep` set to 10 minutes and `step` set to 10%, the 10 hour print will notify me roughly every ten minutes and smaller prints will only notify me every 10%.

Caveat: Octoprint only sends progress event updates in 1% intervals so the frequency of notifications sent via `timeStep` will never be exact (e.g. 1% of a 10 hour print takes 6 minutes so a `timeStep` value of 10 minutes would result in a notification at 2% after 12 minutes had passed). This PR could be refactored to instead have an actual timer that doesn't rely on Octoprint events, but the current implementation was enough for my needs.

(Sorry for all the trailing whitespace removal. My IDE deleted those automatically. You can [view only non-whitespace changes in the PR diff](https://github.com/bchanudet/OctoPrint-Octorant/pull/56/files?diff=split&w=1) or I can revert those changes if you'd prefer.)