### PR TITLE
Update messages_system.jinja2 to fix `Display as Embed` checkboxes

### DIFF
--- a/octoprint_octorant/templates/messages_system.jinja2
+++ b/octoprint_octorant/templates/messages_system.jinja2
@@ -27,8 +27,8 @@
                     Display as Embed
                 </label>
                 <div class="controls">
-                    <textarea type="checkbox" id="octorant_embed_startup" class=""
-                        data-bind="checked: events['startup'].embed_used"></textarea>
+                    <input type="checkbox" id="octorant_embed_startup" class=""
+                        data-bind="checked: events['startup'].embed_used"></input>
                 </div>
             </div>
         </div>
@@ -61,8 +61,8 @@
                     Display as Embed
                 </label>
                 <div class="controls">
-                    <textarea type="checkbox" id="octorant_embed_shutdown" class=""
-                        data-bind="checked: events['shutdown'].embed_used"></textarea>
+                    <input type="checkbox" id="octorant_embed_shutdown" class=""
+                        data-bind="checked: events['shutdown'].embed_used"></input>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Simply changed `<textarea>` tags to `<input>` tags where there should be checkboxes instead of text fields